### PR TITLE
[MISC] Removed tmp and dist from npm publications

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,5 @@ tests/
 bower.json
 Brocfile.js
 testem.json
+tmp/
+dist/


### PR DESCRIPTION
This package requires to download `55M` and uses that on the disk space just because the `tmp` folder is not excluded. Excluding it with `.npmignore`

```bash
$ npm instal --save-dev ember-devtools
ember-devtools@3.0.2 node_modules/ember-devtools
$ du -sh node_modules/ember-devtools
 55M	node_modules/ember-devtools
```