### PR TITLE
Support newer Ember registry location

### DIFF
--- a/app/services/ember-devtools.js
+++ b/app/services/ember-devtools.js
@@ -5,7 +5,7 @@ export default Ember.Object.extend({
   init: function() {
     this.global = this.global || window;
     this.console = this.console || window.console;
-    this.registry = this.container.registry.dict || this.container.registry;
+    this.registry = this.container.registrations || this.container.registry.dict || this.container.registry;
     if (DS !== undefined) {
       this.store = this.container.lookup('store:main');
       this.typeMaps = this.store.typeMaps;


### PR DESCRIPTION
The registry has moved probably during the container refactor, this
update tries the new location first.